### PR TITLE
Posts CURD API 구현, 카운터 API 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "@nestjs/core": "^10.0.0",
         "@nestjs/mapped-types": "*",
         "@nestjs/platform-express": "^10.0.0",
+        "class-transformer": "^0.5.1",
+        "class-validator": "^0.14.1",
         "pg": "^8.11.5",
         "reflect-metadata": "^0.2.0",
         "rxjs": "^7.8.1",
@@ -2264,6 +2266,11 @@
         "@types/superagent": "^8.1.0"
       }
     },
+    "node_modules/@types/validator": {
+      "version": "13.11.9",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.11.9.tgz",
+      "integrity": "sha512-FCTsikRozryfayPuiI46QzH3fnrOoctTjvOYZkho9BTFLCOZ2rgZJHMOVgCOfttjPJcgOx52EpkY0CMfy87MIw=="
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.32",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
@@ -3335,6 +3342,21 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
       "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
       "dev": true
+    },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
+    },
+    "node_modules/class-validator": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.1.tgz",
+      "integrity": "sha512-2VEG9JICxIqTpoK1eMzZqaV+u/EiwEJkMGzTrZf6sU/fwsnOITVgYJ8yojSy6CaXtO9V0Cc6ZQZ8h8m4UBuLwQ==",
+      "dependencies": {
+        "@types/validator": "^13.11.8",
+        "libphonenumber-js": "^1.10.53",
+        "validator": "^13.9.0"
+      }
     },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
@@ -6226,6 +6248,11 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/libphonenumber-js": {
+      "version": "1.10.60",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.60.tgz",
+      "integrity": "sha512-Ctgq2lXUpEJo5j1762NOzl2xo7z7pqmVWYai0p07LvAkQ32tbPv3wb+tcUeHEiXhKU5buM4H9MXsXo6OlM6C2g=="
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -8886,6 +8913,14 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.11.0.tgz",
+      "integrity": "sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,11 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@nestjs/common": "^10.0.0",
+        "@nestjs/config": "^3.2.2",
         "@nestjs/core": "^10.0.0",
         "@nestjs/mapped-types": "*",
         "@nestjs/platform-express": "^10.0.0",
+        "@nestjs/swagger": "^7.3.1",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
         "pg": "^8.11.5",
@@ -1599,6 +1601,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.14.2.tgz",
+      "integrity": "sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug=="
+    },
     "node_modules/@nestjs/cli": {
       "version": "10.3.2",
       "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-10.3.2.tgz",
@@ -1757,6 +1764,21 @@
         }
       }
     },
+    "node_modules/@nestjs/config": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-3.2.2.tgz",
+      "integrity": "sha512-vGICPOui5vE6kPz1iwQ7oCnp3qWgqxldPmBQ9onkVoKlBtyc83KJCr7CjuVtf4OdovMAVcux1d8Q6jglU2ZphA==",
+      "dependencies": {
+        "dotenv": "16.4.5",
+        "dotenv-expand": "10.0.0",
+        "lodash": "4.17.21",
+        "uuid": "9.0.1"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "rxjs": "^7.1.0"
+      }
+    },
     "node_modules/@nestjs/core": {
       "version": "10.3.7",
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.3.7.tgz",
@@ -1854,6 +1876,38 @@
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
       "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
       "dev": true
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-7.3.1.tgz",
+      "integrity": "sha512-LUC4mr+5oAleEC/a2j8pNRh1S5xhKXJ1Gal5ZdRjt9XebQgbngXCdW7JTA9WOEcwGtFZN9EnKYdquzH971LZfw==",
+      "dependencies": {
+        "@microsoft/tsdoc": "^0.14.2",
+        "@nestjs/mapped-types": "2.0.5",
+        "js-yaml": "4.1.0",
+        "lodash": "4.17.21",
+        "path-to-regexp": "3.2.0",
+        "swagger-ui-dist": "5.11.2"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^6.0.0 || ^7.0.0",
+        "@nestjs/common": "^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^9.0.0 || ^10.0.0",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@nestjs/testing": {
       "version": "10.3.7",
@@ -2834,8 +2888,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -3919,6 +3972,14 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
+      "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/eastasianwidth": {
@@ -6134,7 +6195,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -6286,8 +6346,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -8162,6 +8221,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.11.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.11.2.tgz",
+      "integrity": "sha512-jQG0cRgJNMZ7aCoiFofnoojeSaa/+KgWaDlfgs8QN+BXoGMpxeMVY5OEnjq4OlNvF3yjftO8c9GRAgcHlO+u7A=="
     },
     "node_modules/symbol-observable": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "pg": "^8.11.5",
         "reflect-metadata": "^0.2.0",
         "rxjs": "^7.8.1",
+        "swagger-ui-express": "^5.0.0",
         "typeorm": "^0.3.20"
       },
       "devDependencies": {
@@ -8226,6 +8227,20 @@
       "version": "5.11.2",
       "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.11.2.tgz",
       "integrity": "sha512-jQG0cRgJNMZ7aCoiFofnoojeSaa/+KgWaDlfgs8QN+BXoGMpxeMVY5OEnjq4OlNvF3yjftO8c9GRAgcHlO+u7A=="
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.0.tgz",
+      "integrity": "sha512-tsU9tODVvhyfkNSvf03E6FAk+z+5cU3lXAzMy6Pv4av2Gt2xA0++fogwC4qo19XuFf6hdxevPuVCSKFuMHJhFA==",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
+      }
     },
     "node_modules/symbol-observable": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "@nestjs/core": "^10.0.0",
     "@nestjs/mapped-types": "*",
     "@nestjs/platform-express": "^10.0.0",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.1",
     "pg": "^8.11.5",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "pg": "^8.11.5",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",
+    "swagger-ui-express": "^5.0.0",
     "typeorm": "^0.3.20"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,9 +21,11 @@
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",
+    "@nestjs/config": "^3.2.2",
     "@nestjs/core": "^10.0.0",
     "@nestjs/mapped-types": "*",
     "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/swagger": "^7.3.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "pg": "^8.11.5",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,10 +1,18 @@
-import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { ConfigModule } from '@nestjs/config';
+import { Module } from '@nestjs/common';
 import { PostsModule } from './posts/posts.module';
+import configuration from './config/configuration';
 
 @Module({
-  imports: [PostsModule],
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
+      load: [configuration],
+    }),
+    PostsModule,
+  ],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -7,4 +7,10 @@ export default () => ({
     name: process.env.DB_NAME,
     port: parseInt(process.env.DB_PORT) || 5432,
   },
+  swaggerApi: {
+    title: '오늘의 일기 API',
+    description: '오늘의 일기 API Description',
+    version: '0.1',
+    apiRoot: process.env.SWAGGER_API_ROOT,
+  },
 });

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -1,0 +1,10 @@
+export default () => ({
+  port: parseInt(process.env.PORT, 10) || 3000,
+  db: {
+    host: process.env.DB_HOST,
+    username: process.env.DB_USERNAME,
+    password: process.env.DB_PASSWORD,
+    name: process.env.DB_NAME,
+    port: parseInt(process.env.DB_PORT) || 5432,
+  },
+});

--- a/src/config/swagger.config.ts
+++ b/src/config/swagger.config.ts
@@ -1,8 +1,9 @@
 import { DocumentBuilder } from '@nestjs/swagger';
+import config from './configuration';
 
 export const swaggerConfig = new DocumentBuilder()
-  .setTitle('오늘의 일기 API')
-  .setDescription('오늘의 일기 API description')
-  .setVersion('0.1')
+  .setTitle(config().swaggerApi.title)
+  .setDescription(config().swaggerApi.description)
+  .setVersion(config().swaggerApi.version)
   .addBearerAuth()
   .build();

--- a/src/config/swagger.config.ts
+++ b/src/config/swagger.config.ts
@@ -1,0 +1,8 @@
+import { DocumentBuilder } from '@nestjs/swagger';
+
+export const swaggerConfig = new DocumentBuilder()
+  .setTitle('오늘의 일기 API')
+  .setDescription('오늘의 일기 API description')
+  .setVersion('0.1')
+  .addBearerAuth()
+  .build();

--- a/src/database/constants/database.constants.ts
+++ b/src/database/constants/database.constants.ts
@@ -1,0 +1,1 @@
+export const DATA_SOURCE = 'DATA_SOURCE';

--- a/src/database/database.providers.ts
+++ b/src/database/database.providers.ts
@@ -14,6 +14,7 @@ export const databaseProviders = [
         port: configService.get<number>('db.port'),
         entities: [__dirname + '/../**/*.entity{.ts,.js}'],
         synchronize: true,
+        logging: ['query', 'error', 'schema'],
       });
 
       return dataSource.initialize();

--- a/src/database/database.providers.ts
+++ b/src/database/database.providers.ts
@@ -1,21 +1,23 @@
+import { ConfigService } from '@nestjs/config';
+import { DATA_SOURCE } from './constants/database.constants';
 import { DataSource } from 'typeorm';
 
 export const databaseProviders = [
   {
-    provide: 'DATA_SOURCE',
-    useFactory: async () => {
+    provide: DATA_SOURCE,
+    useFactory: async (configService: ConfigService) => {
       const dataSource = new DataSource({
         type: 'postgres',
-        host: 'localhost',
-        port: 5432,
-        username: process.env.DB_USER,
-        password: process.env.DB_PASSWORD,
-        database: 'test',
+        host: configService.get<string>('db.host'),
+        username: configService.get<string>('db.username'),
+        password: configService.get<string>('db.password'),
+        port: configService.get<number>('db.port'),
         entities: [__dirname + '/../**/*.entity{.ts,.js}'],
         synchronize: true,
       });
 
       return dataSource.initialize();
     },
+    inject: [ConfigService],
   },
 ];

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,13 +1,15 @@
 import { AppModule } from './app.module';
 import { NestFactory } from '@nestjs/core';
 import { SwaggerModule } from '@nestjs/swagger';
+import config from './config/configuration';
 import { swaggerConfig } from './config/swagger.config';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
+  const apiRoot = config().swaggerApi.apiRoot;
   const documnet = SwaggerModule.createDocument(app, swaggerConfig);
-  SwaggerModule.setup('api', app, documnet);
+  SwaggerModule.setup(apiRoot, app, documnet);
 
   await app.listen(3000);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,14 @@
 import { AppModule } from './app.module';
 import { NestFactory } from '@nestjs/core';
 import { SwaggerModule } from '@nestjs/swagger';
+import { ValidationPipe } from '@nestjs/common';
 import config from './config/configuration';
 import { swaggerConfig } from './config/swagger.config';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  app.useGlobalPipes(new ValidationPipe());
 
   const apiRoot = config().swaggerApi.apiRoot;
   const documnet = SwaggerModule.createDocument(app, swaggerConfig);

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,11 @@ import { swaggerConfig } from './config/swagger.config';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
-  app.useGlobalPipes(new ValidationPipe());
+  app.useGlobalPipes(
+    new ValidationPipe({
+      transform: true,
+    }),
+  );
 
   const apiRoot = config().swaggerApi.apiRoot;
   const documnet = SwaggerModule.createDocument(app, swaggerConfig);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,14 @@
-import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { NestFactory } from '@nestjs/core';
+import { SwaggerModule } from '@nestjs/swagger';
+import { swaggerConfig } from './config/swagger.config';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  const documnet = SwaggerModule.createDocument(app, swaggerConfig);
+  SwaggerModule.setup('api', app, documnet);
+
   await app.listen(3000);
 }
 bootstrap();

--- a/src/posts/constants/posts.constants.ts
+++ b/src/posts/constants/posts.constants.ts
@@ -1,0 +1,2 @@
+export const POSTS_REPOSITORY = 'POSTS_REPOSITORY';
+export const DATA_SOURCE = 'DATA_SOURCE';

--- a/src/posts/dto/create-post.dto.ts
+++ b/src/posts/dto/create-post.dto.ts
@@ -1,6 +1,27 @@
+import {
+  IsBoolean,
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+} from 'class-validator';
+
+import { PostStatus } from '../enums/posts.enum';
+
 export class CreatePostDto {
+  @IsNotEmpty()
+  @IsString()
   readonly title: string;
+
+  @IsNotEmpty()
+  @IsString()
   readonly content: string;
-  readonly status: string;
-  readonly onlyTeacher: boolean;
+
+  @IsOptional()
+  @IsEnum(PostStatus)
+  readonly status?: PostStatus;
+
+  @IsOptional()
+  @IsBoolean()
+  readonly onlyTeacher?: boolean;
 }

--- a/src/posts/dto/create-post.dto.ts
+++ b/src/posts/dto/create-post.dto.ts
@@ -1,27 +1,26 @@
-import {
-  IsBoolean,
-  IsEnum,
-  IsNotEmpty,
-  IsOptional,
-  IsString,
-} from 'class-validator';
+import { IsBoolean, IsEnum, IsNotEmpty, IsString } from 'class-validator';
 
+import { ApiProperty } from '@nestjs/swagger';
 import { PostStatus } from '../enums/posts.enum';
 
 export class CreatePostDto {
+  @ApiProperty()
   @IsNotEmpty()
   @IsString()
   readonly title: string;
 
+  @ApiProperty()
   @IsNotEmpty()
   @IsString()
   readonly content: string;
 
-  @IsOptional()
+  @ApiProperty({ example: PostStatus.PUBLIC })
+  @IsNotEmpty()
   @IsEnum(PostStatus)
-  readonly status?: PostStatus;
+  readonly status: PostStatus;
 
-  @IsOptional()
+  @ApiProperty({ example: false })
+  @IsNotEmpty()
   @IsBoolean()
-  readonly onlyTeacher?: boolean;
+  readonly onlyTeacher: boolean;
 }

--- a/src/posts/dto/update-post.dto.ts
+++ b/src/posts/dto/update-post.dto.ts
@@ -1,6 +1,37 @@
-import { CreatePostDto } from './create-post.dto';
-import { PartialType } from '@nestjs/mapped-types';
+import {
+  IsBoolean,
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+} from 'class-validator';
 
-export class UpdatePostDto extends PartialType(CreatePostDto) {
+import { ApiProperty } from '@nestjs/swagger';
+import { PostStatus } from '../enums/posts.enum';
+
+export class UpdatePostDto {
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  readonly title?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  readonly content?: string;
+
+  @ApiProperty({ required: false, example: PostStatus.PUBLIC })
+  @IsOptional()
+  @IsEnum(PostStatus)
+  readonly status?: PostStatus;
+
+  @ApiProperty({ required: false, example: false })
+  @IsOptional()
+  @IsBoolean()
+  readonly onlyTeacher?: boolean;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsInt()
   count_view?: number;
 }

--- a/src/posts/dto/update-post.dto.ts
+++ b/src/posts/dto/update-post.dto.ts
@@ -33,5 +33,5 @@ export class UpdatePostDto {
   @ApiProperty({ required: false })
   @IsOptional()
   @IsInt()
-  count_view?: number;
+  views?: number;
 }

--- a/src/posts/dto/update-post.dto.ts
+++ b/src/posts/dto/update-post.dto.ts
@@ -1,4 +1,6 @@
-import { PartialType } from '@nestjs/mapped-types';
 import { CreatePostDto } from './create-post.dto';
+import { PartialType } from '@nestjs/mapped-types';
 
-export class UpdatePostDto extends PartialType(CreatePostDto) {}
+export class UpdatePostDto extends PartialType(CreatePostDto) {
+  count_view?: number;
+}

--- a/src/posts/entities/post.entity.ts
+++ b/src/posts/entities/post.entity.ts
@@ -20,7 +20,7 @@ export class Post {
   content: string;
 
   @Column({ default: 0 })
-  viewCount: number;
+  views: number;
 
   @Column({ type: 'enum', enum: PostStatus, default: PostStatus.PUBLIC })
   status: PostStatus;

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -10,7 +10,9 @@ import {
 import { PostsService } from './posts.service';
 import { CreatePostDto } from './dto/create-post.dto';
 import { UpdatePostDto } from './dto/update-post.dto';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('posts')
 @Controller('posts')
 export class PostsController {
   constructor(private readonly postsService: PostsService) {}

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -6,7 +6,6 @@ import {
   Patch,
   Param,
   Delete,
-  ParseIntPipe,
 } from '@nestjs/common';
 import { PostsService } from './posts.service';
 import { CreatePostDto } from './dto/create-post.dto';
@@ -29,20 +28,18 @@ export class PostsController {
   }
 
   @Get(':id')
-  async findOne(@Param('id') id: string) {
-    return await this.postsService.findOne(+id);
+  async findOne(@Param('id') id: number) {
+    console.log(id);
+    return await this.postsService.findOne(id);
   }
 
   @Patch(':id')
-  async update(
-    @Param('id', ParseIntPipe) id: number,
-    @Body() updatePostDto: UpdatePostDto,
-  ) {
+  async update(@Param('id') id: number, @Body() updatePostDto: UpdatePostDto) {
     return await this.postsService.update(id, updatePostDto);
   }
 
   @Patch(':id/views')
-  async incrementViews(@Param('id') id: string) {
+  async incrementViews(@Param('id') id: number) {
     return await this.postsService.incrementViews(+id);
   }
 

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -35,6 +35,11 @@ export class PostsController {
     return await this.postsService.update(+id, updatePostDto);
   }
 
+  @Patch(':id/views')
+  async incrementViews(@Param('id') id: string) {
+    return await this.postsService.incrementViews(+id);
+  }
+
   @Delete(':id')
   async remove(@Param('id') id: string) {
     return await this.postsService.remove(+id);

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -6,6 +6,7 @@ import {
   Patch,
   Param,
   Delete,
+  ParseIntPipe,
 } from '@nestjs/common';
 import { PostsService } from './posts.service';
 import { CreatePostDto } from './dto/create-post.dto';
@@ -33,8 +34,11 @@ export class PostsController {
   }
 
   @Patch(':id')
-  async update(@Param('id') id: string, @Body() updatePostDto: UpdatePostDto) {
-    return await this.postsService.update(+id, updatePostDto);
+  async update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updatePostDto: UpdatePostDto,
+  ) {
+    return await this.postsService.update(id, updatePostDto);
   }
 
   @Patch(':id/views')

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -1,4 +1,12 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+} from '@nestjs/common';
 import { PostsService } from './posts.service';
 import { CreatePostDto } from './dto/create-post.dto';
 import { UpdatePostDto } from './dto/update-post.dto';
@@ -8,27 +16,27 @@ export class PostsController {
   constructor(private readonly postsService: PostsService) {}
 
   @Post()
-  create(@Body() createPostDto: CreatePostDto) {
-    return this.postsService.create(createPostDto);
+  async create(@Body() createPostDto: CreatePostDto) {
+    return await this.postsService.create(createPostDto);
   }
 
   @Get()
-  findAll() {
-    return this.postsService.findAll();
+  async findAll() {
+    return await this.postsService.findAll();
   }
 
   @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.postsService.findOne(+id);
+  async findOne(@Param('id') id: string) {
+    return await this.postsService.findOne(+id);
   }
 
   @Patch(':id')
-  update(@Param('id') id: string, @Body() updatePostDto: UpdatePostDto) {
-    return this.postsService.update(+id, updatePostDto);
+  async update(@Param('id') id: string, @Body() updatePostDto: UpdatePostDto) {
+    return await this.postsService.update(+id, updatePostDto);
   }
 
   @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.postsService.remove(+id);
+  async remove(@Param('id') id: string) {
+    return await this.postsService.remove(+id);
   }
 }

--- a/src/posts/posts.module.ts
+++ b/src/posts/posts.module.ts
@@ -1,9 +1,12 @@
+import { DatabaseModule } from 'src/database/database.module';
 import { Module } from '@nestjs/common';
-import { PostsService } from './posts.service';
 import { PostsController } from './posts.controller';
+import { PostsService } from './posts.service';
+import { postsProviders } from './providers/posts.providers';
 
 @Module({
+  imports: [DatabaseModule],
   controllers: [PostsController],
-  providers: [PostsService],
+  providers: [...postsProviders, PostsService],
 })
 export class PostsModule {}

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -1,26 +1,38 @@
-import { Injectable } from '@nestjs/common';
 import { CreatePostDto } from './dto/create-post.dto';
+import { Inject, Injectable } from '@nestjs/common';
 import { UpdatePostDto } from './dto/update-post.dto';
+import { Post } from './entities/post.entity';
+import { Repository } from 'typeorm';
 
 @Injectable()
 export class PostsService {
-  create(createPostDto: CreatePostDto) {
-    return 'This action adds a new post';
+  constructor(
+    @Inject('POST_REPOSITORY')
+    private postRepository: Repository<Post>,
+  ) {}
+
+  async create(createPostDto: CreatePostDto): Promise<Post> {
+    const post = new Post();
+    post.title = createPostDto.title;
+    post.content = createPostDto.content;
+    post.status = createPostDto.status;
+    post.onlyTeacher = createPostDto.onlyTeacher;
+    return await this.postRepository.save(post);
   }
 
-  findAll() {
-    return `This action returns all posts`;
+  async findAll() {
+    return await `This action returns all posts`;
   }
 
-  findOne(id: number) {
-    return `This action returns a #${id} post`;
+  async findOne(id: number) {
+    return await `This action returns a #${id} post`;
   }
 
-  update(id: number, updatePostDto: UpdatePostDto) {
-    return `This action updates a #${id} post`;
+  async update(id: number, updatePostDto: UpdatePostDto) {
+    return await this.postRepository.update(id, updatePostDto);
   }
 
-  remove(id: number) {
-    return `This action removes a #${id} post`;
+  async remove(id: number) {
+    return await `This action removes a #${id} post`;
   }
 }

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -22,11 +22,11 @@ export class PostsService {
   }
 
   async findAll() {
-    return await `This action returns all posts`;
+    return await this.postRepository.find();
   }
 
   async findOne(id: number) {
-    return await `This action returns a #${id} post`;
+    return await this.postRepository.findOne({ where: { id } });
   }
 
   async update(id: number, updatePostDto: UpdatePostDto) {
@@ -34,10 +34,10 @@ export class PostsService {
   }
 
   async incrementViews(id: number) {
-    return await this.postRepository.increment({ id }, 'views', 1);
+    await this.postRepository.increment({ id }, 'views', 1);
   }
 
   async remove(id: number) {
-    return await `This action removes a #${id} post`;
+    return await this.postRepository.delete(id);
   }
 }

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -33,6 +33,10 @@ export class PostsService {
     return await this.postRepository.update(id, updatePostDto);
   }
 
+  async incrementViews(id: number) {
+    return await this.postRepository.increment({ id }, 'views', 1);
+  }
+
   async remove(id: number) {
     return await `This action removes a #${id} post`;
   }

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -3,11 +3,12 @@ import { Inject, Injectable } from '@nestjs/common';
 import { UpdatePostDto } from './dto/update-post.dto';
 import { Post } from './entities/post.entity';
 import { Repository } from 'typeorm';
+import { POSTS_REPOSITORY } from './constants/posts.constants';
 
 @Injectable()
 export class PostsService {
   constructor(
-    @Inject('POST_REPOSITORY')
+    @Inject(POSTS_REPOSITORY)
     private postRepository: Repository<Post>,
   ) {}
 

--- a/src/posts/providers/posts.providers.ts
+++ b/src/posts/providers/posts.providers.ts
@@ -1,0 +1,12 @@
+import { DATA_SOURCE, POSTS_REPOSITORY } from '../constants/posts.constants';
+
+import { DataSource } from 'typeorm';
+import { Post } from '../entities/post.entity';
+
+export const postsProviders = [
+  {
+    provide: POSTS_REPOSITORY,
+    useFactory: (dataSource: DataSource) => dataSource.getRepository(Post),
+    inject: [DATA_SOURCE],
+  },
+];


### PR DESCRIPTION
# 구현 사항
**1. postgreSQL DB 연결**
[elephantsql](https://www.elephantsql.com/)의 클라우드로 생성하여 연결하였습니다.

**2. 스웨거 설정**
만들면서 API 문서화까지 동시에 진행되면 좋을 것 같아,
nest 공식 문서 참고해서 스웨거도 함께 생성하였습니다.
[https://docs.nestjs.com/openapi/introduction](https://docs.nestjs.com/openapi/introduction)

**3. Post CURD 구현**
회원, 인증은 구현되지 않았고, 단순히 API 요청으로 게시글을 CRUD하는 기능을 구현하였습니다.

**4. 조회수 +1 구현**
[Patch] `/posts/{id}/views` 로 해당 게시글의 조회수를 1 증가하는 API를 구현하였습니다.

# 구현 중 고민
**1. ORM의 추상화에 의존**
DB의 값을 +1 해주는 작업이 쿼리에 따라 동시성 문제가 발생할 수 있다고 알고 있는데,
typeORM의 `increment` 메서드를 사용해서 구현하는 게 학습에 도움이 되는지 의문입니다.
SQL문을 직접 짜 보는 게 더 도움이 될까 하는 생각이 듭니다.
(ORM이 아닌 SQL을 직접 다루는 게 지금 제 수준에서 필요한지는 의문)

**2. 조회 수 상승 후 응답 값**
조회 수를 올린 후 응답 본문으로 업데이트 된 후의 DB 전체를 반환하는 것과,
아예 응답 본문이 없는 것을 고민하다가 응답 본문을 보내주지 않는 것으로 처리했습니다.

이유는 글을 읽을 때 Get과 Patch(조회 수 상승) 요청이 동시에 갈 텐데,
Patch로 응답 본문을 보내주면 거의 비슷한 정보가 중복해서 회선으로 들어오기 때문에
리소스 낭비라고 생각했습니다.

**3. 로직 구현 방법 고민**
다음 방법을 생각해 보았고, 우선 가장 간단한 방법인 (1)로 구현하였습니다.
(1) 단순히 API 요청 시마다 기계적으로 1증가
(2) 한 회원은 특정 게시글에 조회 수를 1만 올릴 수 있음.(별도의 `posts_views` 테이블 필요)
(3) 프론트엔드에서 처리(세션 스토리지에 조회한 게시글을 추가해 놓고, 하나의 브라우저에서는 게시글 당 한 번만 조회 수 올리기)

처음 ERD 설계할 때는 생각하지 못했는데, API를 구현하다보니 단순히 `Post` 필드의 조회수를 올리는 것 보다
(2)처럼 회원이 읽은 게시글을 별도 테이블에서 관리하는 게 
데이터 분석, 추후 기능 확장에 더 유리하겠다는 생각이 들었습니다.
(읽은 글 히스토리, 추천 글 제안 등 기능 구현 가능)

**4. 여전히 REST 메서드 고민**
만약 별도의 테이블에 게시글 조회 내역을 관리한다면 Post 메서드로 `posts_views` 테이블에 행을 추가할 것 같지만,
`Post` 필드의 조회 수를 올린다면 Patch로 요청을 보내는 게 맞을 것 같습니다.

Get과 Post로 Counter API를 작성하는 게 이번 주 과제인데,
이 경우 Get으로 현재 조회 수를 가져오고, Post로 조회 수를 올린다면
이 두 개의 요청 사이에 다른 사용자의 요청이 들어온다면 카운트가 제대로 반영되지 않을 것 같습니다.

그래서 '조회 수를 가져오고 업데이트'하는 방식이 아닌,
'DB 상의 조회 수를 곧바로 올릴 수 있는 방식'으로 구현하는 게 적절하다고 생각합니다.

조회수는 +1을 하는 작업 외에는 다른 작업이 없기 때문에 Patch 메서드로 구현해도 혼동이 없을 것 같습니다.