### PR TITLE
Feat: Post 모듈 API 인가 포함 구현

### DIFF
--- a/src/auth/strategies/access-token.strategy.ts
+++ b/src/auth/strategies/access-token.strategy.ts
@@ -21,6 +21,6 @@ export class AccessTokenStrategy extends PassportStrategy(Strategy, 'jwt') {
   }
 
   async validate(payload: JwtPayload) {
-    return payload;
+    return { userId: payload.sub, username: payload.username };
   }
 }

--- a/src/common/decorators/user.decorator.ts
+++ b/src/common/decorators/user.decorator.ts
@@ -1,0 +1,9 @@
+import { ExecutionContext, createParamDecorator } from '@nestjs/common';
+
+export const User = createParamDecorator(
+  (data: string, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    const user = request.user;
+    return data ? user?.[data] : user;
+  },
+);

--- a/src/posts/dto/create-post.dto.ts
+++ b/src/posts/dto/create-post.dto.ts
@@ -1,4 +1,11 @@
-import { IsBoolean, IsEnum, IsNotEmpty, IsString } from 'class-validator';
+import {
+  IsBoolean,
+  IsEnum,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+} from 'class-validator';
 
 import { ApiProperty } from '@nestjs/swagger';
 import { PostStatus } from '../enums/posts.enum';
@@ -14,10 +21,14 @@ export class CreatePostDto {
   @IsString()
   readonly content: string;
 
+  @IsOptional()
+  @IsNumber()
+  userId?: number;
+
   @ApiProperty({ example: PostStatus.PUBLIC })
   @IsNotEmpty()
   @IsEnum(PostStatus)
-  readonly status: PostStatus;
+  status: PostStatus;
 
   @ApiProperty({ example: false })
   @IsNotEmpty()

--- a/src/posts/entities/post.entity.ts
+++ b/src/posts/entities/post.entity.ts
@@ -6,12 +6,16 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 
+import { CreatePostDto } from '../dto/create-post.dto';
 import { PostStatus } from '../enums/posts.enum';
 
 @Entity()
 export class Post {
   @PrimaryGeneratedColumn()
   id: number;
+
+  @Column()
+  userId: number;
 
   @Column()
   title: string;
@@ -33,4 +37,14 @@ export class Post {
 
   @UpdateDateColumn()
   updatedAt: Date;
+
+  constructor(createPostDto?: CreatePostDto) {
+    if (createPostDto) {
+      this.title = createPostDto.title;
+      this.content = createPostDto.content;
+      this.userId = createPostDto.userId;
+      this.status = createPostDto.status;
+      this.onlyTeacher = createPostDto.onlyTeacher;
+    }
+  }
 }

--- a/src/posts/guards/post-owner.guard.ts
+++ b/src/posts/guards/post-owner.guard.ts
@@ -1,0 +1,36 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Post } from '../entities/post.entity';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class PostOwnerGuard implements CanActivate {
+  constructor(
+    @InjectRepository(Post)
+    private postRepository: Repository<Post>,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const userId = request.user.userId;
+    const postId = request.params.id;
+
+    const post = await this.postRepository.findOneBy({ id: postId });
+
+    if (!post) {
+      throw new NotFoundException(`Post not found`);
+    }
+
+    if (post.userId !== userId) {
+      throw new UnauthorizedException();
+    }
+
+    return true;
+  }
+}

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -14,8 +14,7 @@ export class PostsService {
   ) {}
 
   async create(createPostDto: CreatePostDto): Promise<Post> {
-    const post = new Post();
-    Object.assign(post, createPostDto);
+    const post = new Post(createPostDto);
     return await this.postRepository.save(post);
   }
 
@@ -24,7 +23,7 @@ export class PostsService {
   }
 
   async findOne(id: number) {
-    return await this.postRepository.findOne({ where: { id } });
+    return await this.postRepository.findOneBy({ id });
   }
 
   async update(id: number, updatePostDto: UpdatePostDto) {

--- a/src/posts/test/posts.service.spec.ts
+++ b/src/posts/test/posts.service.spec.ts
@@ -13,7 +13,7 @@ describe('PostsService', () => {
     mockPostRepository = {
       save: jest.fn().mockResolvedValue({ id: 1 }),
       find: jest.fn().mockResolvedValue([{ id: 1 }]),
-      findOne: jest.fn().mockResolvedValue({ id: 1 }),
+      findOneBy: jest.fn().mockResolvedValue({ id: 1 }),
       update: jest.fn().mockResolvedValue({ id: 1 }),
       increment: jest.fn().mockResolvedValue({ id: 1 }),
       delete: jest.fn().mockResolvedValue({ id: 1 }),
@@ -52,9 +52,7 @@ describe('PostsService', () => {
 
   it('should find one post', async () => {
     expect(await service.findOne(1)).toEqual({ id: 1 });
-    expect(mockPostRepository.findOne).toHaveBeenCalledWith({
-      where: { id: 1 },
-    });
+    expect(mockPostRepository.findOneBy).toHaveBeenCalledWith({ id: 1 });
   });
 
   it('should update a post', async () => {


### PR DESCRIPTION
# 느낀 점

1. 컨트롤러 코드와 테스트 코드를 동시에 작성하니까 비슷한 코드를 두 번씩 작성하는 느낌입니다. 그래서 만약 다른 함수에서 반복되는 코드가 있다면 작업량이 4배로 체감되어서 번거로움이 느껴졌습니다. 그래서 최대한 중복되는 코드를 줄이기 위해 생각해 보게 되었습니다.
ex) jwt에서 userId 추출하기, userId가 유효한지 체크하기와 같은 기능을 데코레이터로 분리

2. 그 전에는 컨트롤러, 서비스 코드를 무작정 작성했다면 테스트 코드와 함께 작성할 때는 2인 3각 달리기를 하는 것처럼 기능을 단계별로 구현하게 됩니다. 그 전에는 컨트롤러 따로, 서비스 따로 코드를 작성했는데 테스트 코드와 함께 쓰면서 레이어 단위로 코드를 작성하는 게 아니라 기능(API)을 위주로 컨트롤러와 서비스를 함께 병행하면서 코드를 작성하게 됩니다.

3. 클래스의 책임에 대해서 생각해 보게 됩니다. 테스트 코드를 작성하면서 '이 기능이 이 레이어에서 진행되어야 되는 건가?'하는 의문이 자주 들었습니다. 클래스 안에서 구현되는 메서드의 기능을 정말 이 클래스 또는 메서드에서 진행해야 하는건지 생각해보게 됩니다.
ex) 해당 post가 존재하는지 여부를 컨트롤러에서 체크하는 게 맞나?(서비스로 이관함)