### PR TITLE
Feat: Topic module

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,7 @@ import { ConfigModule } from '@nestjs/config';
 import { DatabaseModule } from './database/database.module';
 import { Module } from '@nestjs/common';
 import { PostsModule } from './posts/posts.module';
+import { TopicsModule } from './topics/topics.module';
 import configuration from './config/configuration';
 
 @Module({
@@ -13,9 +14,10 @@ import configuration from './config/configuration';
       load: [configuration],
       isGlobal: true,
     }),
+    DatabaseModule,
     AuthModule,
     PostsModule,
-    DatabaseModule,
+    TopicsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/guards/admin.guard.ts
+++ b/src/guards/admin.guard.ts
@@ -1,0 +1,24 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+
+@Injectable()
+export class AdminGuard implements CanActivate {
+  constructor() {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const userId = request.user.userId;
+
+    const adminList = [1];
+
+    if (!adminList.includes(userId)) {
+      throw new UnauthorizedException();
+    }
+
+    return true;
+  }
+}

--- a/src/guards/admin.guard.ts
+++ b/src/guards/admin.guard.ts
@@ -13,6 +13,7 @@ export class AdminGuard implements CanActivate {
     const request = context.switchToHttp().getRequest();
     const userId = request.user.userId;
 
+    // Todo: 권한 제어 하드코딩이 아닌 DB에서 가져오도록 수정
     const adminList = [1];
 
     if (!adminList.includes(userId)) {

--- a/src/topics/dto/create-topic.dto.ts
+++ b/src/topics/dto/create-topic.dto.ts
@@ -1,0 +1,20 @@
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateTopicDto {
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsString()
+  title: string;
+
+  @ApiProperty()
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiProperty({ example: 'private' })
+  @IsNotEmpty()
+  @IsString()
+  status: string = 'private';
+}

--- a/src/topics/dto/update-topic.dto.ts
+++ b/src/topics/dto/update-topic.dto.ts
@@ -1,0 +1,20 @@
+import { IsOptional, IsString } from 'class-validator';
+
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UpdateTopicDto {
+  @ApiProperty()
+  @IsOptional()
+  @IsString()
+  title?: string;
+
+  @ApiProperty()
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiProperty()
+  @IsOptional()
+  @IsString()
+  status?: string;
+}

--- a/src/topics/entities/topic.entity.ts
+++ b/src/topics/entities/topic.entity.ts
@@ -1,0 +1,40 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+import { CreateTopicDto } from '../dto/create-topic.dto';
+import { IsOptional } from 'class-validator';
+
+@Entity()
+export class Topic {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  title: string;
+
+  @Column()
+  @IsOptional()
+  description?: string;
+
+  @Column()
+  status: string = 'private';
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  constructor(createTopicDto?: CreateTopicDto) {
+    if (createTopicDto) {
+      this.title = createTopicDto.title;
+      this.description = createTopicDto.description;
+      this.status = createTopicDto.status;
+    }
+  }
+}

--- a/src/topics/test/topics.controller.spec.ts
+++ b/src/topics/test/topics.controller.spec.ts
@@ -1,0 +1,21 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { TopicsController } from '../topics.controller';
+import { TopicsService } from '../topics.service';
+
+describe('TopicsController', () => {
+  let controller: TopicsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TopicsController],
+      providers: [TopicsService],
+    }).compile();
+
+    controller = module.get<TopicsController>(TopicsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/topics/test/topics.service.spec.ts
+++ b/src/topics/test/topics.service.spec.ts
@@ -1,0 +1,176 @@
+import { DeleteResult, Repository, UpdateResult } from 'typeorm';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { CreateTopicDto } from '../dto/create-topic.dto';
+import { Topic } from '../entities/topic.entity';
+import { TopicsService } from '../topics.service';
+
+describe('TopicsService', () => {
+  let service: TopicsService;
+  let mockTopicsRepository: jest.Mocked<Repository<Topic>>;
+
+  beforeEach(async () => {
+    mockTopicsRepository = {
+      save: jest.fn(),
+      find: jest.fn(),
+      findOneBy: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    } as any;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TopicsService,
+        {
+          provide: 'TopicRepository',
+          useValue: mockTopicsRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<TopicsService>(TopicsService);
+  });
+
+  describe('create', () => {
+    let createTopicDto: CreateTopicDto;
+
+    beforeEach(() => {
+      createTopicDto = {
+        title: 'title',
+        description: 'description',
+        status: 'private',
+      };
+    });
+
+    it('정상 요청인 경우 글쓰기 주제가 생성되어야 한다.', async () => {
+      const expectedTopic = {
+        id: 1,
+        ...createTopicDto,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      mockTopicsRepository.save.mockResolvedValue(expectedTopic);
+
+      const result = await service.create(createTopicDto);
+      expect(result).toEqual(expectedTopic);
+      expect(mockTopicsRepository.save).toHaveBeenCalledWith(createTopicDto);
+    });
+
+    it('비정상 요청인 경우 에러가 발생해야 한다.', async () => {
+      mockTopicsRepository.save.mockRejectedValue(new Error());
+
+      await expect(service.create(createTopicDto)).rejects.toThrow();
+    });
+  });
+
+  describe('findAll', () => {
+    it('모든 글쓰기 주제를 반환해야 한다.', async () => {
+      const expectedTopics = [{ id: 1 }, { id: 2 }] as Topic[];
+      mockTopicsRepository.find.mockResolvedValue(expectedTopics);
+
+      const result = await service.findAll();
+      expect(result).toEqual(expectedTopics);
+      expect(mockTopicsRepository.find).toHaveBeenCalled();
+    });
+
+    it('글쓰기 주제가 없는 경우 빈 배열을 반환해야 한다.', async () => {
+      mockTopicsRepository.find.mockResolvedValue([]);
+
+      const result = await service.findAll();
+      expect(result).toEqual([]);
+    });
+
+    it('비정상 요청인 경우 에러가 발생해야 한다.', async () => {
+      mockTopicsRepository.find.mockRejectedValue(new Error());
+
+      await expect(service.findAll()).rejects.toThrow();
+    });
+  });
+
+  describe('findOne', () => {
+    it('특정 글쓰기 주제를 반환해야 한다.', async () => {
+      const expectedTopic = { id: 1 } as Topic;
+      mockTopicsRepository.findOneBy.mockResolvedValue(expectedTopic);
+
+      const result = await service.findOne(1);
+      expect(result).toEqual(expectedTopic);
+      expect(mockTopicsRepository.findOneBy).toHaveBeenCalledWith({ id: 1 });
+    });
+
+    it('글쓰기 주제가 없는 경우 null을 반환해야 한다.', async () => {
+      mockTopicsRepository.findOneBy.mockResolvedValue(null);
+
+      const result = await service.findOne(1);
+      expect(result).toBeNull();
+    });
+
+    it('비정상 요청인 경우 에러가 발생해야 한다.', async () => {
+      mockTopicsRepository.findOneBy.mockRejectedValue(new Error());
+
+      await expect(service.findOne(1)).rejects.toThrow();
+    });
+  });
+
+  describe('update', () => {
+    let updateTopicDto: CreateTopicDto;
+
+    beforeEach(() => {
+      updateTopicDto = {
+        title: 'update-title',
+        description: 'description',
+        status: 'private',
+      };
+    });
+
+    it('정상 요청인 경우 글쓰기 주제가 수정되어야 한다.', async () => {
+      const updateResult = {
+        affected: 1,
+      } as UpdateResult;
+
+      mockTopicsRepository.update.mockResolvedValue(updateResult);
+
+      const result = await service.update(1, updateTopicDto);
+      expect(result).toEqual(updateResult);
+      expect(mockTopicsRepository.update).toHaveBeenCalledWith(
+        1,
+        updateTopicDto,
+      );
+    });
+
+    it('비정상 요청인 경우 에러가 발생해야 한다.', async () => {
+      mockTopicsRepository.update.mockRejectedValue(new Error());
+
+      await expect(service.update(1, updateTopicDto)).rejects.toThrow();
+    });
+  });
+
+  describe('remove', () => {
+    it('정상 요청인 경우 글쓰기 주제가 삭제되어야 한다.', async () => {
+      const deleteResult = {
+        affected: 1,
+      } as DeleteResult;
+
+      mockTopicsRepository.delete.mockResolvedValue(deleteResult);
+
+      const result = await service.remove(1);
+      expect(result).toEqual(deleteResult);
+      expect(mockTopicsRepository.delete).toHaveBeenCalledWith(1);
+    });
+
+    it('글쓰기 주제가 없는 경우, affected가 0인 결과를 반환해야 한다.', async () => {
+      const deleteResult = {
+        affected: 0,
+      } as DeleteResult;
+
+      mockTopicsRepository.delete.mockResolvedValue(deleteResult);
+
+      await expect(service.remove(1)).resolves.toEqual(deleteResult);
+    });
+
+    it('비정상 요청인 경우 에러가 발생해야 한다.', async () => {
+      mockTopicsRepository.delete.mockRejectedValue(new Error());
+
+      await expect(service.remove(1)).rejects.toThrow();
+    });
+  });
+});

--- a/src/topics/topics.controller.ts
+++ b/src/topics/topics.controller.ts
@@ -1,0 +1,53 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  UseGuards,
+} from '@nestjs/common';
+import { TopicsService } from './topics.service';
+import { CreateTopicDto } from './dto/create-topic.dto';
+import { UpdateTopicDto } from './dto/update-topic.dto';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { AuthGuard } from '@nestjs/passport';
+import { AdminGuard } from 'src/guards/admin.guard';
+
+@ApiTags('topics')
+@Controller('topics')
+export class TopicsController {
+  constructor(private readonly topicsService: TopicsService) {}
+
+  @Post()
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard('jwt'), AdminGuard)
+  create(@Body() createTopicDto: CreateTopicDto) {
+    return this.topicsService.create(createTopicDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.topicsService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: number) {
+    return this.topicsService.findOne(id);
+  }
+
+  @Patch(':id')
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard('jwt'), AdminGuard)
+  update(@Param('id') id: number, @Body() updateTopicDto: UpdateTopicDto) {
+    return this.topicsService.update(id, updateTopicDto);
+  }
+
+  @Delete(':id')
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard('jwt'), AdminGuard)
+  remove(@Param('id') id: number) {
+    return this.topicsService.remove(id);
+  }
+}

--- a/src/topics/topics.module.ts
+++ b/src/topics/topics.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { Topic } from './entities/topic.entity';
+import { TopicsController } from './topics.controller';
+import { TopicsService } from './topics.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Topic])],
+  controllers: [TopicsController],
+  providers: [TopicsService],
+})
+export class TopicsModule {}

--- a/src/topics/topics.service.ts
+++ b/src/topics/topics.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@nestjs/common';
+
+import { CreateTopicDto } from './dto/create-topic.dto';
+import { Repository } from 'typeorm';
+import { Topic } from './entities/topic.entity';
+import { UpdateTopicDto } from './dto/update-topic.dto';
+import { InjectRepository } from '@nestjs/typeorm';
+
+@Injectable()
+export class TopicsService {
+  constructor(
+    @InjectRepository(Topic)
+    private topicRepository: Repository<Topic>,
+  ) {}
+
+  async create(createTopicDto: CreateTopicDto) {
+    const topic = new Topic(createTopicDto);
+    return await this.topicRepository.save(topic);
+  }
+
+  async findAll() {
+    return await this.topicRepository.find();
+  }
+
+  async findOne(id: number) {
+    return await this.topicRepository.findOneBy({ id });
+  }
+
+  async update(id: number, updateTopicDto: UpdateTopicDto) {
+    return await this.topicRepository.update(id, updateTopicDto);
+  }
+
+  async remove(id: number) {
+    return await this.topicRepository.delete(id);
+  }
+}


### PR DESCRIPTION
Topic 모듈 기능 구현하였습니다.

# Nest 학습
Nest 파이프라인에 대해서 전반적으로 다시 복습했습니다.
미들웨어, 필터, 파이프, 가드, 인터셉터가 이제 유기적으로 연결되는 게 느껴집니다.

Topic 객체의 생성/수정/삭제는 관리자 권한인 경우에만 가능한데, Nest의 파이프라인 개념이 어느정도 잡혀서 어떻게 구현해야 할지 개요는 바로 떠올라서 신기했습니다.

가급적 GPT 도움 없이 구현해 보려고 노력하였습니다.


# 테스트 코드
Jest 유튜브 강의 영상을 보면서 테스트의 흐름에 대해서 이해하려고 노력했습니다.
지난 번 테스트는 우선 구현에 급급했다면, 이번에는 나름대로 깔끔한 테스트를 해보려고 노력했습니다.


# 코드 리뷰 관련
이 정도의 PR이 리뷰를 진행하기에 사이즈가 어떤지 궁금합니다.