### PR TITLE
Feat: 학급 모듈

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,7 @@ import { DatabaseModule } from './database/database.module';
 import { Module } from '@nestjs/common';
 import { PostsModule } from './posts/posts.module';
 import { TopicsModule } from './topics/topics.module';
+import { ClassroomsModule } from './classrooms/classrooms.module';
 import configuration from './config/configuration';
 
 @Module({
@@ -18,6 +19,7 @@ import configuration from './config/configuration';
     AuthModule,
     PostsModule,
     TopicsModule,
+    ClassroomsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/classrooms/classrooms.controller.ts
+++ b/src/classrooms/classrooms.controller.ts
@@ -1,0 +1,52 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  UseGuards,
+} from '@nestjs/common';
+import { ClassroomsService } from './classrooms.service';
+import { CreateClassroomDto } from './dto/create-classroom.dto';
+import { UpdateClassroomDto } from './dto/update-classroom.dto';
+import { AuthGuard } from '@nestjs/passport';
+
+@Controller('classrooms')
+export class ClassroomsController {
+  constructor(private readonly classroomsService: ClassroomsService) {}
+
+  @Post()
+  @UseGuards(AuthGuard('jwt'))
+  async create(@Body() createClassroomDto: CreateClassroomDto) {
+    return await this.classroomsService.create(createClassroomDto);
+  }
+
+  @Get()
+  async findAll() {
+    return await this.classroomsService.findAll();
+  }
+
+  @Get(':id')
+  async findOne(@Param('id') id: number) {
+    return await this.classroomsService.findOne(id);
+  }
+
+  @Patch(':id')
+  // TODO: 학급 개설자만 수정할 수 있도록 수정
+  @UseGuards(AuthGuard('jwt'))
+  async update(
+    @Param('id') id: number,
+    @Body() updateClassroomDto: UpdateClassroomDto,
+  ) {
+    return await this.classroomsService.update(id, updateClassroomDto);
+  }
+
+  @Delete(':id')
+  // TODO: 학급 개설자만 삭제할 수 있도록 수정
+  @UseGuards(AuthGuard('jwt'))
+  async remove(@Param('id') id: number) {
+    return await this.classroomsService.remove(id);
+  }
+}

--- a/src/classrooms/classrooms.module.ts
+++ b/src/classrooms/classrooms.module.ts
@@ -1,0 +1,12 @@
+import { Classroom } from './entities/classroom.entity';
+import { ClassroomsController } from './classrooms.controller';
+import { ClassroomsService } from './classrooms.service';
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Classroom])],
+  controllers: [ClassroomsController],
+  providers: [ClassroomsService],
+})
+export class ClassroomsModule {}

--- a/src/classrooms/classrooms.service.ts
+++ b/src/classrooms/classrooms.service.ts
@@ -1,0 +1,46 @@
+import { CreateClassroomDto } from './dto/create-classroom.dto';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { UpdateClassroomDto } from './dto/update-classroom.dto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Classroom } from './entities/classroom.entity';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class ClassroomsService {
+  constructor(
+    @InjectRepository(Classroom)
+    private classroomRepository: Repository<Classroom>,
+  ) {}
+
+  async create(createClassroomDto: CreateClassroomDto) {
+    return await this.classroomRepository.save(createClassroomDto);
+  }
+
+  async findAll() {
+    return await this.classroomRepository.find();
+  }
+
+  async findOne(id: number) {
+    return await this.classroomRepository.findOneBy({ id });
+  }
+
+  async update(id: number, updateClassroomDto: UpdateClassroomDto) {
+    const result = await this.classroomRepository.update(
+      id,
+      updateClassroomDto,
+    );
+
+    if (result.affected === 0) {
+      throw new NotFoundException(`Classroom with ID ${id} not found.`);
+    }
+    return result;
+  }
+
+  async remove(id: number) {
+    const result = await this.classroomRepository.delete(id);
+    if (result.affected === 0) {
+      throw new NotFoundException(`Classroom with ID ${id} not found.`);
+    }
+    return result;
+  }
+}

--- a/src/classrooms/dto/create-classroom.dto.ts
+++ b/src/classrooms/dto/create-classroom.dto.ts
@@ -1,0 +1,34 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateClassroomDto {
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsString()
+  schoolYear: number;
+
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsString()
+  grade: number;
+
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsString()
+  classSection: string;
+
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsString()
+  teacherId: number;
+
+  @ApiProperty()
+  @IsString()
+  bio?: string;
+
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsString()
+  pin: string;
+}

--- a/src/classrooms/dto/update-classroom.dto.ts
+++ b/src/classrooms/dto/update-classroom.dto.ts
@@ -1,0 +1,32 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+
+export class UpdateClassroomDto {
+  @ApiProperty()
+  @IsString()
+  schoolYear?: number;
+
+  @ApiProperty()
+  @IsString()
+  grade?: number;
+
+  @ApiProperty()
+  @IsString()
+  classSection?: string;
+
+  @ApiProperty()
+  @IsString()
+  teacherId?: number;
+
+  @ApiProperty()
+  @IsString()
+  bio?: string;
+
+  @ApiProperty()
+  @IsString()
+  pin?: string;
+
+  @ApiProperty()
+  @IsString()
+  isActive?: boolean;
+}

--- a/src/classrooms/entities/classroom.entity.ts
+++ b/src/classrooms/entities/classroom.entity.ts
@@ -1,0 +1,41 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity()
+export class Classroom {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  schoolYear: number;
+
+  @Column()
+  grade: number;
+
+  @Column()
+  classSection: string;
+
+  // TODO: 외래키 설정
+  @Column()
+  teacherId: number;
+
+  @Column()
+  bio: string;
+
+  @Column()
+  pin: string;
+
+  @Column()
+  isActive: boolean;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/classrooms/test/classrooms.controller.spec.ts
+++ b/src/classrooms/test/classrooms.controller.spec.ts
@@ -1,0 +1,149 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { Classroom } from '../entities/classroom.entity';
+import { ClassroomsController } from '../classrooms.controller';
+import { ClassroomsService } from '../classrooms.service';
+import { CreateClassroomDto } from '../dto/create-classroom.dto';
+import { NotFoundException } from '@nestjs/common';
+import { UpdateResult } from 'typeorm';
+
+describe('ClassroomsController', () => {
+  let controller: ClassroomsController;
+  let mockClassroomsService: jest.Mocked<Partial<ClassroomsService>>;
+
+  beforeEach(async () => {
+    mockClassroomsService = {
+      create: jest.fn(),
+      findAll: jest.fn(),
+      findOne: jest.fn(),
+      update: jest.fn(),
+      remove: jest.fn(),
+    } as any;
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ClassroomsController],
+      providers: [
+        {
+          provide: ClassroomsService,
+          useValue: mockClassroomsService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<ClassroomsController>(ClassroomsController);
+  });
+
+  describe('create', () => {
+    let createClassroomDto: CreateClassroomDto;
+
+    beforeEach(() => {
+      createClassroomDto = {} as CreateClassroomDto;
+    });
+
+    it('정상 요청인 경우 학급 생성 서비스를 호출하고 학습 생성 결과를 반환해야 한다.', async () => {
+      const expectedClassroom = {
+        id: 1,
+      } as Classroom;
+
+      mockClassroomsService.create.mockResolvedValue(expectedClassroom);
+
+      const result = await controller.create(createClassroomDto);
+      expect(result).toEqual(expectedClassroom);
+      expect(mockClassroomsService.create).toHaveBeenCalledWith(
+        createClassroomDto,
+      );
+    });
+  });
+
+  describe('findAll', () => {
+    it('모든 학급을 반환해야 한다.', async () => {
+      const expectedClassrooms = [
+        {
+          id: 1,
+        } as Classroom,
+      ];
+
+      mockClassroomsService.findAll.mockResolvedValue(expectedClassrooms);
+
+      const result = await controller.findAll();
+      expect(result).toEqual(expectedClassrooms);
+    });
+
+    it('학급이 없는 경우 빈 배열을 반환해야 한다.', async () => {
+      const expectedClassrooms = [];
+
+      mockClassroomsService.findAll.mockResolvedValue(expectedClassrooms);
+
+      const result = await controller.findAll();
+      expect(result).toEqual(expectedClassrooms);
+    });
+  });
+
+  describe('findOne', () => {
+    it('특정 학급을 반환해야 한다.', async () => {
+      const expectedClassroom = {
+        id: 1,
+      } as Classroom;
+
+      mockClassroomsService.findOne.mockResolvedValue(expectedClassroom);
+
+      const result = await controller.findOne(1);
+      expect(result).toEqual(expectedClassroom);
+    });
+  });
+
+  describe('update', () => {
+    let updateClassroomDto: CreateClassroomDto;
+
+    beforeEach(() => {
+      updateClassroomDto = {} as CreateClassroomDto;
+    });
+
+    it('정상 요청인 경우 학급 수정 서비스를 호출하고 학습 수정 결과를 반환해야 한다.', async () => {
+      const expectedClassroom = {
+        affected: 1,
+      } as UpdateResult;
+
+      mockClassroomsService.update.mockResolvedValue(expectedClassroom);
+
+      const result = await controller.update(1, updateClassroomDto);
+      expect(result).toEqual(expectedClassroom);
+      expect(mockClassroomsService.update).toHaveBeenCalledWith(
+        1,
+        updateClassroomDto,
+      );
+    });
+
+    it('수정할 학급이 없는 경우 404 에러를 반환해야 한다.', async () => {
+      const expectedError = new NotFoundException();
+
+      mockClassroomsService.update.mockRejectedValue(expectedError);
+
+      await expect(controller.update(1, updateClassroomDto)).rejects.toThrow(
+        expectedError,
+      );
+    });
+  });
+
+  describe('remove', () => {
+    it('정상 요청인 경우 학급 삭제 서비스를 호출하고 학습 삭제 결과를 반환해야 한다.', async () => {
+      const expectedClassroom = {
+        affected: 1,
+      } as UpdateResult;
+
+      mockClassroomsService.remove.mockResolvedValue(expectedClassroom);
+
+      const result = await controller.remove(1);
+      expect(result).toEqual(expectedClassroom);
+      expect(mockClassroomsService.remove).toHaveBeenCalledWith(1);
+    });
+
+    it('삭제할 학급이 없는 경우 404 에러를 반환해야 한다.', async () => {
+      const expectedError = new NotFoundException();
+
+      mockClassroomsService.remove.mockRejectedValue(expectedError);
+
+      await expect(controller.remove(1)).rejects.toThrow(expectedError);
+    });
+  });
+});

--- a/src/classrooms/test/classrooms.service.spec.ts
+++ b/src/classrooms/test/classrooms.service.spec.ts
@@ -1,0 +1,154 @@
+import { DeleteResult, Repository, UpdateResult } from 'typeorm';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { Classroom } from '../entities/classroom.entity';
+import { ClassroomsService } from '../classrooms.service';
+import { CreateClassroomDto } from '../dto/create-classroom.dto';
+import { NotFoundException } from '@nestjs/common';
+
+describe('ClassroomsService', () => {
+  let service: ClassroomsService;
+  let mockClassroomRepository: jest.Mocked<Repository<Classroom>>;
+
+  beforeEach(async () => {
+    mockClassroomRepository = {
+      save: jest.fn(),
+      find: jest.fn(),
+      findOneBy: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    } as any;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ClassroomsService,
+        {
+          provide: 'ClassroomRepository',
+          useValue: mockClassroomRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<ClassroomsService>(ClassroomsService);
+  });
+
+  describe('create', () => {
+    let createClassroomDto: CreateClassroomDto;
+
+    beforeEach(() => {
+      createClassroomDto = {} as CreateClassroomDto;
+    });
+
+    it('정상 요청인 경우 학급이 생성되어야 한다.', async () => {
+      const expectedClassroom = {
+        id: 1,
+      } as Classroom;
+
+      mockClassroomRepository.save.mockResolvedValue(expectedClassroom);
+
+      const result = await service.create(createClassroomDto);
+      expect(result).toEqual(expectedClassroom);
+      expect(mockClassroomRepository.save).toHaveBeenCalledWith(
+        createClassroomDto,
+      );
+    });
+  });
+
+  describe('findAll', () => {
+    it('모든 학급을 반환해야 한다.', async () => {
+      const expectedClassrooms = [
+        {
+          id: 1,
+        },
+      ] as Classroom[];
+
+      mockClassroomRepository.find.mockResolvedValue(expectedClassrooms);
+
+      const result = await service.findAll();
+      expect(result).toEqual(expectedClassrooms);
+      expect(mockClassroomRepository.find).toHaveBeenCalled();
+    });
+  });
+
+  describe('findOne', () => {
+    it('특정 학급을 반환해야 한다.', async () => {
+      const expectedClassroom = {
+        id: 1,
+      } as Classroom;
+
+      mockClassroomRepository.findOneBy.mockResolvedValue(expectedClassroom);
+
+      const result = await service.findOne(1);
+      expect(result).toEqual(expectedClassroom);
+      expect(mockClassroomRepository.findOneBy).toHaveBeenCalledWith({ id: 1 });
+    });
+
+    it('특정 학급이 없는 경우 null을 반환해야 한다.', async () => {
+      mockClassroomRepository.findOneBy.mockResolvedValue(null);
+
+      const result = await service.findOne(1);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('update', () => {
+    let updateClassroomDto: CreateClassroomDto;
+
+    beforeEach(() => {
+      updateClassroomDto = {} as CreateClassroomDto;
+    });
+
+    it('정상 요청인 경우 학급이 수정되어야 한다.', async () => {
+      const updateResult = {
+        affected: 1,
+      } as UpdateResult;
+
+      mockClassroomRepository.update.mockResolvedValue(updateResult);
+
+      const result = await service.update(1, updateClassroomDto);
+      expect(result).toEqual(updateResult);
+      expect(mockClassroomRepository.update).toHaveBeenCalledWith(1, {});
+    });
+
+    it('특정 학급이 없는 경우 에러가 발생해야 한다.', async () => {
+      const expectedError = new NotFoundException(
+        `Classroom with ID 1 not found.`,
+      );
+
+      mockClassroomRepository.update.mockRejectedValue(expectedError);
+      const result = service.update(1, updateClassroomDto);
+
+      expect(result).rejects.toThrow(expectedError);
+      expect(mockClassroomRepository.update).toHaveBeenCalledWith(
+        1,
+        updateClassroomDto,
+      );
+    });
+  });
+
+  describe('remove', () => {
+    it('특정 학급을 삭제해야 한다.', async () => {
+      const expectedDeleteResult = {
+        affected: 1,
+      } as DeleteResult;
+
+      mockClassroomRepository.delete.mockResolvedValue(expectedDeleteResult);
+
+      const result = await service.remove(1);
+      expect(result).toEqual(expectedDeleteResult);
+      expect(mockClassroomRepository.delete).toHaveBeenCalledWith(1);
+    });
+
+    it('특정 학급이 없는 경우 에러가 발생해야 한다.', async () => {
+      const expectedError = new NotFoundException(
+        `Classroom with ID 1 not found.`,
+      );
+
+      mockClassroomRepository.delete.mockRejectedValue(expectedError);
+      const result = service.remove(1);
+
+      expect(result).rejects.toThrow(expectedError);
+      expect(mockClassroomRepository.delete).toHaveBeenCalledWith(1);
+    });
+  });
+});


### PR DESCRIPTION
학급 모듈 완성하였습니다.
로직과 테스트 코드를 동시에 작성하면서 더 느껴지는 점이 많았습니다.

그 전에 Topic 모듈을 작성할 때는 업데이트 또는 삭제 성공/실패를 affected 필드를 통해서 판별했는데,
생각해보니 최종적으로 응답이 이런 객체 형태로 오는 건 뭔가 이상했습니다.
(현재 스웨거에서 Topic이나 Post 모듈을 수정/삭제 여부가 affected 필드가 포함된 객체가 반환되는 형태입니다.)

그래서 로직 내에서 affected 필드에서 0과 1을 분기처리해서 문제가 있는 경우 적절히 에러를 throw 해야 하지 않나? 하는 생각이 들었습니다.
그런데 이런 식으로 처리하다 보니 중복된 코드라는 생각이 들어 이것도 데코레이터를 통해 한번에 처리해야 하지 않나 싶은 생각도 들었습니다.

해당 코드 부분에 코멘트 남겨 놓겠습니다!