### PR TITLE
Feat: 회원 가입 시 이벤트 발생하여 포인트 객체 자동 생성

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@nestjs/common": "^10.0.0",
         "@nestjs/config": "^3.2.2",
         "@nestjs/core": "^10.0.0",
+        "@nestjs/cqrs": "^10.2.7",
         "@nestjs/jwt": "^10.2.0",
         "@nestjs/mapped-types": "*",
         "@nestjs/passport": "^10.0.3",
@@ -1824,6 +1825,20 @@
         "@nestjs/websockets": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/cqrs": {
+      "version": "10.2.7",
+      "resolved": "https://registry.npmjs.org/@nestjs/cqrs/-/cqrs-10.2.7.tgz",
+      "integrity": "sha512-RXhgQOfuT+KzvkueR4S++SB6+6333PL71pOtCzbJAAU/DY3KY56yTCncWRsIdorKfDX5AEwTiQHHJi69XJWdkA==",
+      "dependencies": {
+        "uuid": "9.0.1"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^9.0.0 || ^10.0.0",
+        "reflect-metadata": "^0.1.13 || ^0.2.0",
+        "rxjs": "^7.2.0"
       }
     },
     "node_modules/@nestjs/jwt": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@nestjs/common": "^10.0.0",
     "@nestjs/config": "^3.2.2",
     "@nestjs/core": "^10.0.0",
+    "@nestjs/cqrs": "^10.2.7",
     "@nestjs/jwt": "^10.2.0",
     "@nestjs/mapped-types": "*",
     "@nestjs/passport": "^10.0.3",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,14 +1,17 @@
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
+import { ClassroomsModule } from './classrooms/classrooms.module';
 import { ConfigModule } from '@nestjs/config';
+import { CqrsModule } from '@nestjs/cqrs';
 import { DatabaseModule } from './database/database.module';
 import { Module } from '@nestjs/common';
+import { PointTransactionsModule } from './point-transactions/point-transactions.module';
+import { PointsModule } from './points/points.module';
 import { PostsModule } from './posts/posts.module';
 import { TopicsModule } from './topics/topics.module';
-import { ClassroomsModule } from './classrooms/classrooms.module';
-import { PointsModule } from './points/points.module';
-import { PointTransactionsModule } from './point-transactions/point-transactions.module';
+import { UserCreatedHandler } from './points/events/handler/user-created.handler';
+import { UsersModule } from './users/users.module';
 import configuration from './config/configuration';
 
 @Module({
@@ -18,7 +21,9 @@ import configuration from './config/configuration';
       isGlobal: true,
     }),
     DatabaseModule,
+    CqrsModule,
     AuthModule,
+    UsersModule,
     PostsModule,
     TopicsModule,
     ClassroomsModule,
@@ -26,6 +31,6 @@ import configuration from './config/configuration';
     PointTransactionsModule,
   ],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [AppService, UserCreatedHandler],
 })
 export class AppModule {}

--- a/src/point-transactions/point-transactions.module.ts
+++ b/src/point-transactions/point-transactions.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
-import { PointTransactionsService } from './point-transactions.service';
+import { PointTransaction } from './entities/point-transaction.entity';
 import { PointTransactionsController } from './point-transactions.controller';
+import { PointTransactionsService } from './point-transactions.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([PointTransaction])],
   controllers: [PointTransactionsController],
   providers: [PointTransactionsService],
 })

--- a/src/point-transactions/point-transactions.service.ts
+++ b/src/point-transactions/point-transactions.service.ts
@@ -1,5 +1,5 @@
-import { Injectable } from '@nestjs/common';
 import { CreatePointTransactionDto } from './dto/create-point-transaction.dto';
+import { Injectable } from '@nestjs/common';
 import { UpdatePointTransactionDto } from './dto/update-point-transaction.dto';
 
 @Injectable()

--- a/src/points/entities/point.entity.ts
+++ b/src/points/entities/point.entity.ts
@@ -1,6 +1,7 @@
 import {
   Column,
   CreateDateColumn,
+  Entity,
   JoinColumn,
   OneToOne,
   PrimaryGeneratedColumn,
@@ -9,6 +10,7 @@ import {
 
 import { User } from 'src/users/entities/user.entity';
 
+@Entity()
 export class Point {
   @PrimaryGeneratedColumn()
   id: number;

--- a/src/points/events/handler/user-created.handler.ts
+++ b/src/points/events/handler/user-created.handler.ts
@@ -1,0 +1,14 @@
+import { EventsHandler, IEventHandler } from '@nestjs/cqrs';
+
+import { PointsService } from 'src/points/points.service';
+import { UserCreatedEvent } from 'src/users/events/user-created.event';
+
+@EventsHandler(UserCreatedEvent)
+export class UserCreatedHandler implements IEventHandler<UserCreatedEvent> {
+  constructor(private readonly pointsService: PointsService) {}
+
+  async handle(event: UserCreatedEvent) {
+    const newPoint = this.pointsService.create({ userId: event.userId });
+    return newPoint;
+  }
+}

--- a/src/points/points.module.ts
+++ b/src/points/points.module.ts
@@ -3,10 +3,12 @@ import { Point } from './entities/point.entity';
 import { PointsController } from './points.controller';
 import { PointsService } from './points.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { UsersModule } from 'src/users/users.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Point])],
+  imports: [TypeOrmModule.forFeature([Point]), UsersModule],
   controllers: [PointsController],
   providers: [PointsService],
+  exports: [PointsService],
 })
 export class PointsModule {}

--- a/src/points/points.service.ts
+++ b/src/points/points.service.ts
@@ -1,5 +1,5 @@
 import { CreatePointDto } from './dto/create-point.dto';
-import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Point } from './entities/point.entity';
 import { Repository } from 'typeorm';
@@ -10,7 +10,6 @@ export class PointsService {
   constructor(
     @InjectRepository(Point)
     private pointRepository: Repository<Point>,
-    @Inject(UsersService)
     private usersService: UsersService,
   ) {}
 

--- a/src/users/events/user-created.event.ts
+++ b/src/users/events/user-created.event.ts
@@ -1,0 +1,3 @@
+export class UserCreatedEvent {
+  constructor(public readonly userId: number) {}
+}

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,3 +1,4 @@
+import { CqrsModule } from '@nestjs/cqrs';
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from './entities/user.entity';
@@ -5,7 +6,7 @@ import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User])],
+  imports: [TypeOrmModule.forFeature([User]), CqrsModule],
   providers: [UsersService],
   controllers: [UsersController],
   exports: [UsersService],


### PR DESCRIPTION
point 모듈과 points-transaction 모듈을 생성하였습니다.
의도한 기능은 user가 생성되면 1:1로 연계되는 point 객체를 따로 생성하는 것입니다.
point 객체는 포인트 증감이 발생할 때마다 point-transaction이 생성됩니다.(트랜잭션도 별도의 모듈)

모듈 생성에 따른 기본 기능은 리뷰 없이 머지하였습니다.

이번 구현에서 중점을 둔 부분은 '회원 가입을 했을 때 자동으로 해당 유저와 1:1로 연동되는 Point 객체를 만드는 것'이었습니다.

1. 처음에는 User모듈과 Point모듈을 서로 참조해서 user가 생성되면, create 함수 안에서 point service의 create 함수를 호출하는 방식으로 구현하였습니다. 그런데 이때 User 모듈과 Point 모듈이 서로 각각 참조해서 순환 참조 문제가 발생하였습니다. forward로 이 문제를 해결할 수 있다고는 했는데, 뭔가 회피하는 방식이 들어서 다른 방식을 찾아보았고, @nestjs/cqrs 패키지로 이벤트를 발생시키고 핸들러를 동작하는 형태로 구현하는 방법을 찾았습니다.

2. user와 point를 외래키로 참조하는 과정에서 외래키의 양방향/단방향 참조에 대해서 공부했고, 외래키 설정에 관한 의문이 다소 해결되었습니다.

3. 각 모듈을 improt하고 의존성을 export하고, provide하는 과정에서 여러 버그가 있었고 이를 해결하는 과정에서 이해도가 더 올라갔습니다.