### PR TITLE
Feat: cronjob for post views

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@nestjs/mapped-types": "*",
         "@nestjs/passport": "^10.0.3",
         "@nestjs/platform-express": "^10.0.0",
+        "@nestjs/schedule": "^4.1.0",
         "@nestjs/swagger": "^7.3.1",
         "@nestjs/typeorm": "^10.0.2",
         "argon2": "^0.40.1",
@@ -2163,6 +2164,31 @@
         "@nestjs/core": "^10.0.0"
       }
     },
+    "node_modules/@nestjs/schedule": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-4.1.0.tgz",
+      "integrity": "sha512-WEc96WTXZW+VI/Ng+uBpiBUwm6TWtAbQ4RKWkfbmzKvmbRGzA/9k/UyAWDS9k0pp+ZcbC+MaZQtt7TjQHrwX6g==",
+      "dependencies": {
+        "cron": "3.1.7",
+        "uuid": "10.0.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/@nestjs/schedule/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@nestjs/schematics": {
       "version": "10.1.1",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-10.1.1.tgz",
@@ -2724,6 +2750,11 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.4.2.tgz",
+      "integrity": "sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA=="
     },
     "node_modules/@types/methods": {
       "version": "1.1.4",
@@ -4650,6 +4681,15 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "devOptional": true
+    },
+    "node_modules/cron": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-3.1.7.tgz",
+      "integrity": "sha512-tlBg7ARsAMQLzgwqVxy8AZl/qlTc5nibqYwtNGoCrd+cV+ugI+tvZC1oT/8dFH8W455YrywGykx/KMmAqOr7Jw==",
+      "dependencies": {
+        "@types/luxon": "~3.4.0",
+        "luxon": "~3.4.0"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -8071,6 +8111,14 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
+      "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@nestjs/mapped-types": "*",
     "@nestjs/passport": "^10.0.3",
     "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/schedule": "^4.1.0",
     "@nestjs/swagger": "^7.3.1",
     "@nestjs/typeorm": "^10.0.2",
     "argon2": "^0.40.1",

--- a/src/redis/redis.service.ts
+++ b/src/redis/redis.service.ts
@@ -21,4 +21,16 @@ export class RedisService {
   async incr(key: string) {
     return await this.redis.incr(key);
   }
+
+  async expire(key: string, ttl: number) {
+    return await this.redis.expire(key, ttl);
+  }
+
+  async decrby(key: string, decrement: number) {
+    return await this.redis.decrby(key, decrement);
+  }
+
+  async keys(pattern: string) {
+    return await this.redis.keys(pattern);
+  }
 }


### PR DESCRIPTION
조회 수를 캐싱해서, DB I/O를 줄이면 좋지 않을까? 하는 생각으로 이것 저것 시도해봤는데,
의문만 남는 작업이었습니다.

만료 시간을 설정하고, 특정 시간 동안 조회수가 기준 이상이면 인기글로 설정하고,
인기글인 경우 조회 수를 모아 반영하고,
그렇지 않은 경우 실시간으로 반영되게도 해 보았으나,
코드가 굉장히 지저분해지고 매 조회마다 redis에 접속해야 하는데
오히려 더 오버헤드가 커지는 것 같아 철회하였습니다.

우선 기존대로 일정 단위로 조회수가 반영되고,
크론잡을 실행해서 조회수를 일정 시간마다 동기화 시킬 수 있는 함수를 구현하였고,
실제 크론잡은 세팅하지는 않았습니다.

이번 redis 작업을 하면서 느낀 점이
"캐싱이라는 건 멱등성이 있는 작업에 한해서만 효율적인건가?" 하는 점이었습니다.
조회수를 올리는 것처럼 멱등하지 않은 작업에 억지로 캐싱을 적용하려고하다 보니 
풀어내기가 어려웠나 하는 생각도 들었습니다.

그래도 이것 저것 해본 덕분에 redis 메서드를 더 써 볼 수 있어서 익숙해졌습니다.
